### PR TITLE
index will raise ValueError when the substring is not found.

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -46,7 +46,7 @@ class LeetCodeCrawler:
                 browser.get(login_url)
 
                 WebDriverWait(browser, 24 * 60 * 3600).until(
-                    lambda driver: driver.current_url.index("login") < 0
+                    lambda driver: driver.current_url.find("login") < 0
                 )
                 browser_cookies = browser.get_cookies()
                 with open(COOKIE_PATH, 'wb') as f:


### PR DESCRIPTION
Fix the following error message:
Login Failed: substring not found, please try again

The man page of python string:
https://docs.python.org/2/library/string.html#string.index

Signed-off-by: Yu-Chen Lin <npes87184@gmail.com>