### PR TITLE
Feature: remove image when template image load error

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -184,7 +184,8 @@ class LeetCodeCrawler:
 
         # parse data
         solution = get(body, "data.question")
-        if solution['solution']['paidOnly'] is False:
+        solutionExist = solution['solution'] is not None and solution['solution']['paidOnly'] is False
+        if solutionExist:
             Solution.replace(
                 problem=solution['questionId'],
                 url=f"https://leetcode.com/articles/{slug}/",

--- a/templates/back-side.html
+++ b/templates/back-side.html
@@ -8,7 +8,9 @@
                 </p>
                 <section style="width: 180px; margin-right: auto; margin-left: auto;">
                     <img src="http://img.xdnphb.com/ueditor/edit/upload/image/20171214/1513222917052065016.png"
-                         style="display: block;width: 100%; vertical-align:top;"/>
+                         style="display: block;width: 100%; vertical-align:top;"
+                         onerror="this.parentNode.removeChild(this)"
+                         />
                 </section>
             </section>
         </section>
@@ -26,7 +28,9 @@
                 </p>
                 <section style="width: 180px; margin-right: auto; margin-left: auto;">
                     <img src="http://img.xdnphb.com/ueditor/edit/upload/image/20171214/1513222917052065016.png"
-                         style="display: block;width: 100%; vertical-align:top;"/>
+                         style="display: block;width: 100%; vertical-align:top;"
+                         onerror="this.parentNode.removeChild(this)"
+                         />
                 </section>
             </section>
         </section>

--- a/templates/front-side.html
+++ b/templates/front-side.html
@@ -59,7 +59,9 @@
                 </p>
                 <section style="width: 180px; margin-right: auto; margin-left: auto;">
                     <img src="http://img.xdnphb.com/ueditor/edit/upload/image/20171214/1513222917052065016.png"
-                         style="display: block;width: 100%; vertical-align:top;"/>
+                         style="display: block;width: 100%; vertical-align:top;"
+                         onerror="this.parentNode.removeChild(this)"
+                         />
                 </section>
             </section>
         </section>


### PR DESCRIPTION
  the image below address is invalided now .  http://img.xdnphb.com/ueditor/edit/upload/image/20171214/1513222917052065016.png"
  so the template will be render like this:
<img width="354" alt="Snipaste_2022-06-30_20-25-06" src="https://user-images.githubusercontent.com/8892970/176677853-8e577ff8-933d-43a9-9d20-5950ae5f7aa9.png">
I added an error handler to remove image when it not be loaded.
<img width="415" alt="image" src="https://user-images.githubusercontent.com/8892970/176678897-037c7e1a-bdcd-48df-bd99-0be1b62e46ff.png">

